### PR TITLE
fix prompt_inputs["input_ids"] length issue

### DIFF
--- a/src/r1-v/src/open_r1/trainer/grpo_trainer.py
+++ b/src/r1-v/src/open_r1/trainer/grpo_trainer.py
@@ -440,6 +440,12 @@ class Qwen2VLGRPOTrainer(Trainer):
         
         prompt_inputs = super()._prepare_inputs(prompt_inputs)
 
+
+        # fix prompt_inputs["input_ids"] length issue
+        if self.max_prompt_length is not None:
+            prompt_inputs["input_ids"] = prompt_inputs["input_ids"][:, -self.max_prompt_length :]
+            prompt_inputs["attention_mask"] = prompt_inputs["attention_mask"][:, -self.max_prompt_length :]
+
         prompt_ids, prompt_mask = prompt_inputs["input_ids"], prompt_inputs["attention_mask"]
 
         


### PR DESCRIPTION
Fix issue with prompt_inputs["input_ids"] length mismatch, following implementations from R1-V and Open-R1-Video:

1. https://github.com/Wang-Xiaodong1899/Open-R1-Video/blob/50eb65f32f7f0b3c9bc20b74046ef1b5d960088e/src/open_r1_video/trainer/grpo_trainer.py#L369
2. https://github.com/Deep-Agent/R1-V/blob/bbbbe3dc1ea6a74ce31c118c1722b1ee73e372ba/src/r1-v/src/open_r1/trainer/grpo_trainer.py#L377